### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+  
+  - package-ecosystem: "pip"
+    directory: "sdk/orm-django"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "examples/django-encryption-example"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Dependabot requires the directory property to point at the actual package to update.
For multiple packages, it needs multiple entries.